### PR TITLE
Automatically install phpredis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Redis Utilities for VVV
 
-This package is meant to automate the installation and configuration of [Redis](https://redis.io/) in [Varying Vagrant Vagrants (VVV)](https://varyingvagrantvagrants.org/) environments.
+This package is meant to automate the installation and configuration of [Redis](https://redis.io/) and [phpredis](https://github.com/phpredis/phpredis) in [Varying Vagrant Vagrants (VVV)](https://varyingvagrantvagrants.org/) environments.
 
-The latest version of Redis will be built and installed from source, providing your VVV environment with a powerful in-memory data store and queuing system.
+The latest version of Redis will be built and installed from source, providing your VVV environment with a powerful in-memory data store and queuing system. Additionally, phpredis will be installed, exposing access to Redis from within your PHP applications.
 
 For more information on how to use Redis, [please see the Redis documentation](https://redis.io/documentation).
 
@@ -40,10 +40,10 @@ PONG
 
 ## Support
 
-This package has been designed to work with the latest versions of VVV, adhering to the [instructions provided in the official Redis Quick Start Guide](https://redis.io/topics/quickstart), using setup scripts that ship with Redis itself.
+This package has been designed to work with the latest versions of VVV, adhering to the [instructions provided in the official Redis Quick Start Guide](https://redis.io/topics/quickstart), using setup scripts that ship with Redis itself. Meanwhile, phpredis is configured to [install the latest stable release via PECL](https://github.com/phpredis/phpredis/blob/develop/INSTALL.markdown#installation-from-pecl).
 
 That being said, bugs do happen from time to time in software. If you run into trouble, [please open an issue on GitHub](https://github.com/stevegrunwell/vvv-redis/issues/new) and we'll try to help you through it!
 
 ## License
 
-This package is licensed under the [MIT License](license.txt), while Redis itself is released under [the BSD 3-Clause "New" or "Revised" License](https://github.com/antirez/redis/blob/unstable/COPYING).
+This package is licensed under the [MIT License](license.txt), while Redis itself is released under [the BSD 3-Clause "New" or "Revised" License](https://github.com/antirez/redis/blob/unstable/COPYING) and phpredis is available under [the PHP License, version 3.01](http://www.php.net/license/3_01.txt).

--- a/redis/provision.sh
+++ b/redis/provision.sh
@@ -30,3 +30,14 @@ sudo REDIS_CONFIG_FILE="/etc/redis/${REDIS_PORT}.conf" \
     REDIS_DATA_DIR="/var/lib/redis/${REDIS_PORT}" \
     REDIS_EXECUTABLE="$(command -v redis-server)" \
     ./utils/install_server.sh
+
+# Install phpredis via PECL.
+yes '' | sudo pecl install redis || exit 1
+
+# Create redis.ini files for each version of PHP.
+for DIR in /etc/php/*/mods-available; do
+    echo "extension=redis.so" | sudo tee "$DIR/redis.ini" > /dev/null
+done
+
+# Enable the Redis PHP module.
+sudo phpenmod redis


### PR DESCRIPTION
This PR scripts in [the installation of phpredis](https://github.com/phpredis/phpredis/blob/develop/INSTALL.markdown), enabling developers to work with Redis out of the box using the native, C-based PHP extension.

Fixes #1.